### PR TITLE
feat: add X (Twitter) button to homepage

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Github, Settings } from 'lucide-react'
+import { Github, Settings, Twitter } from 'lucide-react'
 import SettingsModal from './SettingsModal'
 
 const Header = ({ 
@@ -39,6 +39,16 @@ const Header = ({
         >
           <Github size={14} />
           {t('github')}
+        </a>
+        <a 
+          href="https://x.com/being99/status/1944176927478325631" 
+          target="_blank" 
+          rel="noopener noreferrer"
+          className="github-link"
+          title="Follow us on X (Twitter)"
+        >
+          <Twitter size={14} />
+          X
         </a>
       </div>
       


### PR DESCRIPTION
Added an X button to the homepage header that links to the specified Twitter status for user communication.

- Added Twitter icon from lucide-react
- Placed alongside GitHub link in header
- Links to https://x.com/being99/status/1944176927478325631
- Uses existing styling for consistent appearance

Closes #2