### PR TITLE
Add server-mode fallback so the GUI works in Firefox

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -67,6 +67,39 @@ PORT=8080 CLAUDE_DIR=/custom/path/.claude bun run start
 - `POST /api/sessions/:project/:session/continue` - Continue conversation
 - `POST /api/sessions/:project` - Create new session
 
+#### `GET /api/projects` response
+
+Each session entry includes its `summary` and `timestamp` so the web GUI can
+render and sort the sidebar without a request per session:
+
+```json
+{
+  "projects": [
+    {
+      "name": "-home-user-my-project",
+      "displayName": "/home/user/my/project",
+      "sessionCount": 2,
+      "sessions": [
+        { "id": "abc123", "summary": "Fix the build", "timestamp": "2026-01-02T03:04:05.000Z" },
+        { "id": "def456", "summary": "Add tests", "timestamp": "2026-01-01T10:00:00.000Z" }
+      ]
+    }
+  ]
+}
+```
+
+#### `GET /api/sessions/:project/:session` response
+
+```json
+{
+  "id": "abc123",
+  "projectName": "-home-user-my-project",
+  "summary": "Fix the build",
+  "timestamp": "2026-01-02T03:04:05.000Z",
+  "messages": [ /* user / assistant records */ ]
+}
+```
+
 ### Example: Continue Conversation
 ```bash
 curl -X POST http://localhost:3000/api/sessions/my-project/session-123/continue \

--- a/server/server.js
+++ b/server/server.js
@@ -22,9 +22,9 @@ app.use('*', cors({
   allowHeaders: ['Content-Type', 'Authorization'],
 }))
 
-// Serve static files from parent directory
+// Serve the built GUI (vite build outputs to ../dist)
 app.use('/*', serveStatic({
-  root: join(__dirname, '..'),
+  root: join(__dirname, '..', 'dist'),
   rewriteRequestPath: (path) => path.replace(/^\//, '')
 }))
 
@@ -39,6 +39,35 @@ app.get('/api/health', (c) => {
   })
 })
 
+// Extract a session's summary + last timestamp from its JSONL content.
+// Mirrors the GUI's own metadata logic: prefer an explicit summary record,
+// fall back to the first user message, then to 'Untitled'.
+function extractSessionMeta(content) {
+  const lines = content.trim().split('\n')
+  let summary = null
+  let firstMessage = null
+  let lastTimestamp = null
+
+  for (const line of lines) {
+    try {
+      const record = JSON.parse(line)
+      if (record.type === 'summary') {
+        summary = record.summary
+      } else if (record.type === 'user' && !firstMessage) {
+        const content = record.message?.content
+        if (typeof content === 'string') firstMessage = content
+      }
+      if (record.timestamp) {
+        lastTimestamp = record.timestamp
+      }
+    } catch (e) {
+      // Ignore parsing errors
+    }
+  }
+
+  return { summary: summary || firstMessage || 'Untitled', timestamp: lastTimestamp }
+}
+
 // Get projects list
 app.get('/api/projects', async (c) => {
   try {
@@ -51,14 +80,26 @@ app.get('/api/projects', async (c) => {
     for (const project of projects) {
       if (project.isDirectory()) {
         const projectPath = join(projectsDir, project.name)
-        const sessions = await readdir(projectPath)
-        const sessionFiles = sessions.filter(file => file.endsWith('.jsonl'))
-        
+        const entries = await readdir(projectPath)
+        const sessionFiles = entries.filter(file => file.endsWith('.jsonl'))
+
+        // Read each session's metadata (summary + timestamp) up front so the
+        // GUI's sidebar doesn't have to fetch every session individually.
+        const sessions = await Promise.all(sessionFiles.map(async (file) => {
+          const id = file.replace('.jsonl', '')
+          try {
+            const content = await readFile(join(projectPath, file), 'utf-8')
+            return { id, ...extractSessionMeta(content) }
+          } catch (e) {
+            return { id, summary: id, timestamp: null }
+          }
+        }))
+
         projectList.push({
           name: project.name,
           displayName: project.name.replace(/-/g, '/'),
           sessionCount: sessionFiles.length,
-          sessions: sessionFiles.map(file => file.replace('.jsonl', ''))
+          sessions
         })
       }
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import ShareModal from './components/ShareModal'
 
 // Import utilities
 import { ClaudeCodeManager } from './utils/claudeCodeManager'
+import { isServerAvailable } from './utils/serverApi'
 import { useLanguage } from './hooks/useLanguage'
 
 function App() {
@@ -41,9 +42,24 @@ function App() {
   const requestDirectoryAccess = useCallback(async () => {
     try {
       if (!('showDirectoryPicker' in window)) {
-        setAppState(prev => ({ 
-          ...prev, 
-          error: t('errors.unsupported') 
+        // Firefox / no File System Access API: fall back to the local server
+        if (await isServerAvailable()) {
+          setAppState(prev => ({ ...prev, loading: true, error: null }))
+          const { projects, allSessions } = await claudeManager.loadProjectsFromServer()
+          setAppState(prev => ({
+            ...prev,
+            view: 'sessions',
+            directoryHandle: null,
+            projects,
+            allSessions,
+            loading: false,
+            error: null
+          }))
+          return
+        }
+        setAppState(prev => ({
+          ...prev,
+          error: t('errors.unsupported')
         }))
         return
       }

--- a/src/utils/claudeCodeManager.js
+++ b/src/utils/claudeCodeManager.js
@@ -1,5 +1,6 @@
 // Claude Code Manager - handles all core functionality for React version
 import { Utils } from './utils'
+import { fetchProjects, fetchSession } from './serverApi'
 export class ClaudeCodeManager {
   constructor() {
     this.gistManager = new GistManager()
@@ -161,12 +162,45 @@ export class ClaudeCodeManager {
       
       // Load session metadata
       const sessionsWithData = await this.loadAllSessionsMetadata(allSessions)
-      
+
       return { projects, allSessions: sessionsWithData }
-      
+
     } catch (error) {
       throw new Error(`Failed to load projects: ${error.message}`)
     }
+  }
+
+  // Server-mode equivalent of loadProjects(): reads from the bundled Bun
+  // server over HTTP instead of the File System Access API. Returns the same
+  // { projects, allSessions } shape, but sessions carry projectName + id
+  // instead of a file handle (see loadSessionMessages for the read branch).
+  async loadProjectsFromServer() {
+    const rawProjects = await fetchProjects()
+    const projects = []
+    const allSessions = []
+
+    for (const p of rawProjects) {
+      // /api/projects already includes per-session summary + timestamp, so no
+      // per-session round-trips are needed here.
+      const sessions = p.sessions.map((s) => ({
+        id: s.id,
+        projectName: p.name,
+        summary: s.summary || 'Untitled',
+        timestamp: s.timestamp,
+      }))
+
+      projects.push({
+        name: p.displayName,
+        path: p.name,
+        sessions: sessions,
+      })
+
+      allSessions.push(...sessions)
+    }
+
+    // Sort by time (newest first), matching loadAllSessionsMetadata
+    const sorted = allSessions.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
+    return { projects, allSessions: sorted }
   }
 
   async loadAllSessionsMetadata(sessions) {
@@ -213,6 +247,11 @@ export class ClaudeCodeManager {
   }
 
   async loadSessionMessages(session) {
+    // Server mode: no file handle, fetch messages from the API instead
+    if (!session.handle) {
+      const data = await fetchSession(session.projectName, session.id)
+      return data.messages
+    }
     try {
       const file = await session.handle.getFile()
       const content = await file.text()

--- a/src/utils/serverApi.js
+++ b/src/utils/serverApi.js
@@ -1,0 +1,33 @@
+// Server API client - reads projects/sessions over HTTP from the bundled
+// Bun server (server/server.js). Works in Firefox and other browsers that
+// lack the File System Access API, since it only uses fetch().
+
+// Same-origin by default: the GUI is served by the server on :3000, so the
+// API lives at the same origin. Override only if you serve GUI and API apart.
+const API_BASE = ''
+
+export async function isServerAvailable() {
+  try {
+    const res = await fetch(`${API_BASE}/api/health`, { cache: 'no-store' })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+export async function fetchProjects() {
+  const res = await fetch(`${API_BASE}/api/projects`)
+  if (!res.ok) throw new Error(`Server returned ${res.status}`)
+  const { projects } = await res.json()
+  // [{ name, displayName, sessionCount, sessions: [{ id, summary, timestamp }...] }]
+  return projects
+}
+
+export async function fetchSession(projectName, sessionId) {
+  const res = await fetch(
+    `${API_BASE}/api/sessions/${encodeURIComponent(projectName)}/${encodeURIComponent(sessionId)}`
+  )
+  if (!res.ok) throw new Error(`Server returned ${res.status}`)
+  // { id, projectName, summary, timestamp, messages }
+  return res.json()
+}


### PR DESCRIPTION
## Problem

The GUI reads `~/.claude` via the **File System Access API** (`window.showDirectoryPicker`), which only exists in Chromium-based browsers. In Firefox (and Safari) the app dead-ends on an "unsupported browser" message, since Mozilla has [declined to ship](https://mozilla.github.io/standards-positions/#native-file-system) the local-disk pickers.

## Solution

When `showDirectoryPicker` is unavailable, the GUI now checks for the **bundled local server** (`server/`) via `/api/health` and, if it's running, loads projects and sessions over HTTP instead. The server already serves the GUI same-origin, so there's no CORS or picker involved — it just works in Firefox.

**Chromium browsers are unaffected** — they keep using the File System Access API exactly as before. The server is only consulted when the picker is missing, so the "no server required" experience is preserved for existing users.

## Changes

- **`src/utils/serverApi.js`** *(new)* — tiny `fetch()` client: `isServerAvailable()`, `fetchProjects()`, `fetchSession()`.
- **`src/utils/claudeCodeManager.js`** — adds `loadProjectsFromServer()` (returns the same `{ projects, allSessions }` shape as the FS path); `loadSessionMessages()` fetches over HTTP when a session has no file handle.
- **`src/App.jsx`** — server fallback in the no-`showDirectoryPicker` branch instead of erroring out.
- **`server/server.js`** — `/api/projects` now includes per-session `summary` + `timestamp` so the sidebar needs no per-session round-trips; serves the built GUI from `../dist` (vite's `build.outDir`) instead of the repo root.

## How to use (Firefox)

```bash
npm install && npm run build
cd server && bun install && bun run start   # serves GUI + API on :3000
```

Open `http://localhost:3000` in Firefox and click "open folder" — it detects the server and loads your sessions.

## Testing

- `npm run build` passes cleanly.
- Ran the server against a real `~/.claude/projects` (10 projects): `/api/health`, `/api/projects` (now returning `summary`/`timestamp` per session), and GUI-from-`dist` all verified working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)